### PR TITLE
Canonicalize header names on response.

### DIFF
--- a/lib/celluloid/eventsource/response_parser.rb
+++ b/lib/celluloid/eventsource/response_parser.rb
@@ -26,7 +26,7 @@ module Celluloid
       end
 
       def on_headers_complete(headers)
-        @headers = headers
+        @headers = canonical_headers(headers)
       end
 
       def on_body(chunk)
@@ -42,6 +42,18 @@ module Celluloid
         chunk.to_s
       end
 
+      private
+
+      def canonical_headers(headers)
+        headers.each_with_object({}) do |(key, value), canonicalized_headers|
+          name = canonicalize_header(key)
+          canonicalized_headers[name] = value
+        end
+      end
+
+      def canonicalize_header(name)
+        name.gsub('_', '-').split("-").map(&:capitalize).join("-")
+      end
     end
 
   end

--- a/spec/celluloid/eventsource/response_parser_spec.rb
+++ b/spec/celluloid/eventsource/response_parser_spec.rb
@@ -7,8 +7,10 @@ HTTP/1.1 200 OK
 Last-Modified: Wed, 08 Jan 2003 23:11:55 GMT
 Content-Type: text/html; charset=UTF-8
 Content-Length: 131
-  eos
-  }
+X_CASE_HEADER: foo
+X_Mixed-Case: bar
+eos
+}
 
   let(:error_headers) {<<-eos
 HTTP/1.1 400 OK
@@ -50,4 +52,13 @@ eos
     expect(parser.headers?).to be_false
     expect(parser.headers).to be_nil
   end
+
+  it 'makes response headers canonicalized' do
+    streamed(response_string) { |line| parser << line }
+    expected_headers = {
+      'X-Mixed-Case' => 'bar', 'Content-Type' => 'text/html; charset=UTF-8', 'Content-Length' => "131", 'X-Case-Header' => 'foo'
+    }
+    expect(parser.headers).to include(expected_headers)
+  end
+
 end


### PR DESCRIPTION
This will capitalize each word separated by '-' or '_' and convert '_' to '-'.

Fixes #5 
