### PR TITLE
Allow case insentitive header checking

### DIFF
--- a/lib/celluloid/eventsource.rb
+++ b/lib/celluloid/eventsource.rb
@@ -125,7 +125,7 @@ module Celluloid
       when /^retry:(\d+)$/
         @reconnect_timeout = $1.to_i
       when /^event:(.+)$/
-        @event_type_buffer = $1.lstrip
+        @event_type_buffer = $1.lstrip.chomp
       end
     end
 


### PR DESCRIPTION
Some http clients send the Content-type header in lowercase. This commit allows for both options.
