### PR TITLE
Update celluloid-io dependency to 0.16.2

### DIFF
--- a/celluloid-eventsource.gemspec
+++ b/celluloid-eventsource.gemspec
@@ -18,13 +18,13 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'celluloid-io', '~> 0.15.0'
+  spec.add_dependency 'celluloid-io', '>= 0.15.0', '<= 0.16.2'
   spec.add_dependency 'http_parser.rb', '~> 0.6.0'
 
   spec.add_development_dependency "timers"
   spec.add_development_dependency "reel", '>= 0.5.0'
   spec.add_development_dependency "rspec", '~> 3.0.0'
-  spec.add_development_dependency "bundler", "~> 1.7.0"
+  spec.add_development_dependency "bundler", ">= 1.7.0"
   spec.add_development_dependency "rake", '~> 10.1.0'
   spec.add_development_dependency "pry", '~> 0.9.0'
 end


### PR DESCRIPTION
I've just updated the gemspec to use the latest celluloid-io. The specs are green and there shouldn't be any [backward compat issues](https://github.com/celluloid/celluloid-io/blob/master/CHANGES.md).

Cheers!